### PR TITLE
remove ramda dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "effects-as-data-node",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -402,6 +402,12 @@
       "integrity": "sha1-r+3IU70/jcNUjqZx++adA8wsF2c=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
@@ -634,6 +640,16 @@
         "babel-helper-regex": "6.24.1",
         "babel-runtime": "6.23.0",
         "regexpu-core": "2.0.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+      "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
+        "babel-runtime": "6.23.0"
       }
     },
     "babel-plugin-transform-regenerator": {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "license": "MIT",
   "dependencies": {
     "effects-as-data-universal": "^2.0.6",
-    "ramda": "^0.24.1",
     "readline": "^1.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "jest-cli": "^20.0.0",
     "sinon": "^2.3.8"

--- a/src/cmds/index.js
+++ b/src/cmds/index.js
@@ -1,14 +1,14 @@
-const { merge } = require('ramda')
 const { env } = require('./env')
 const { requireModule } = require('./require-module')
 const { readFile, writeFile } = require('./fs')
 const { prompt } = require('./prompt')
 const { cmds: universal } = require('effects-as-data-universal')
 
-module.exports = merge(universal, {
+module.exports = {
+  ...universal,
   env,
   requireModule,
   readFile,
   writeFile,
   prompt
-})
+}

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -1,13 +1,13 @@
-const { merge } = require('ramda')
 const { env } = require('./env')
 const { requireModule } = require('./require-module')
 const { node } = require('./node')
 const { prompt } = require('./prompt')
 const { handlers: universal } = require('effects-as-data-universal')
 
-module.exports = merge(universal, {
+module.exports = {
+  ...universal,
   env,
   requireModule,
   node,
   prompt
-})
+}


### PR DESCRIPTION
Added babel `Object rest spread transform` since merge was the only ramda function we were using.